### PR TITLE
escape asterisk symbol to get better behavior

### DIFF
--- a/setantenv.sh
+++ b/setantenv.sh
@@ -18,9 +18,9 @@
 OWN_NAME=setantenv.sh
 
 if [ "$0" == "./$OWN_NAME" ]; then
-	echo * Please call as ". ./$OWN_NAME", not ./$OWN_NAME !!!---
-	echo * Also please DO NOT set back the executable attribute
-	echo * On this file. It was cleared on purpose.
+	echo \* Please call as ". ./$OWN_NAME", not ./$OWN_NAME !!!---
+	echo \* Also please DO NOT set back the executable attribute
+	echo \* On this file. It was cleared on purpose.
 	
 	chmod -x ./$OWN_NAME
 	exit


### PR DESCRIPTION
'echo * ' sentence expands to all filenames of this folder like 'dir' command. 
We need to escape \* this symbol