### PR TITLE
Build properties update acs

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -565,7 +565,7 @@ demo.download.commerce-ep.amc.core=/content/companies/private/day_internal/packa
 demo.download.commerce-ep.amc.version=aem61
 
 #AEM ACS Commons and tools downloads
-demo.download.acs.1.core=https://github.com/Adobe-Consulting-Services/acs-aem-commons/releases/download/acs-aem-commons-2.8.0/acs-aem-commons-content-2.8.0.zip
+demo.download.acs.1.core=https://github.com/Adobe-Consulting-Services/acs-aem-commons/releases/download/acs-aem-commons-2.9.0/acs-aem-commons-content-2.9.0.zip
 demo.download.acs.1.version=aem61
 demo.download.acs.2.core=https://github.com/Adobe-Consulting-Services/acs-aem-commons/releases/download/acs-aem-commons-3.6.2/acs-aem-commons-content-3.6.2.zip
 demo.download.acs.2.version=aem62

--- a/build.properties
+++ b/build.properties
@@ -565,7 +565,7 @@ demo.download.commerce-ep.amc.core=/content/companies/private/day_internal/packa
 demo.download.commerce-ep.amc.version=aem61
 
 #AEM ACS Commons and tools downloads
-demo.download.acs.1.core=https://github.com/Adobe-Consulting-Services/acs-aem-commons/releases/download/acs-aem-commons-2.6.10/acs-aem-commons-content-2.8.0.zip
+demo.download.acs.1.core=https://github.com/Adobe-Consulting-Services/acs-aem-commons/releases/download/acs-aem-commons-2.8.0/acs-aem-commons-content-2.8.0.zip
 demo.download.acs.1.version=aem61
 demo.download.acs.2.core=https://github.com/Adobe-Consulting-Services/acs-aem-commons/releases/download/acs-aem-commons-3.6.2/acs-aem-commons-content-3.6.2.zip
 demo.download.acs.2.version=aem62

--- a/build.properties
+++ b/build.properties
@@ -567,15 +567,15 @@ demo.download.commerce-ep.amc.version=aem61
 #AEM ACS Commons and tools downloads
 demo.download.acs.1.core=https://github.com/Adobe-Consulting-Services/acs-aem-commons/releases/download/acs-aem-commons-2.6.10/acs-aem-commons-content-2.8.0.zip
 demo.download.acs.1.version=aem61
-demo.download.acs.2.core=https://github.com/Adobe-Consulting-Services/acs-aem-commons/releases/download/acs-aem-commons-3.3.2/acs-aem-commons-content-3.5.2.zip
+demo.download.acs.2.core=https://github.com/Adobe-Consulting-Services/acs-aem-commons/releases/download/acs-aem-commons-3.6.2/acs-aem-commons-content-3.6.2.zip
 demo.download.acs.2.version=aem62
 demo.download.acs.3.core=https://github.com/Adobe-Consulting-Services/com.adobe.acs.bundles.netty/releases/download/com.adobe.acs.bundles.netty-1.0.2/com.adobe.acs.bundles.netty-1.0.2.zip
 demo.download.acs.3.version=all
-demo.download.acs.4.core=https://github.com/Adobe-Consulting-Services/acs-aem-tools/releases/download/acs-aem-tools-0.0.28/acs-aem-tools-content-0.0.28.zip
+demo.download.acs.4.core=https://github.com/Adobe-Consulting-Services/acs-aem-tools/releases/download/acs-aem-tools-0.0.40/acs-aem-tools-content-0.0.40.zip
 demo.download.acs.4.version=all
 demo.download.acs.5.core=https://github.com/Adobe-Consulting-Services/com.adobe.acs.bundles.twitter4j/releases/download/com.adobe.acs.bundles.twitter4j-1.0.0/com.adobe.acs.bundles.twitter4j-content-1.0.0.zip
 demo.download.acs.5.version=all
-demo.download.acs.6.core=https://github.com/Adobe-Consulting-Services/acs-aem-commons/releases/download/acs-aem-commons-3.3.2/acs-aem-commons-content-3.5.2.zip
+demo.download.acs.6.core=https://github.com/Adobe-Consulting-Services/acs-aem-commons/releases/download/acs-aem-commons-3.6.2/acs-aem-commons-content-3.6.2.zip
 demo.download.acs.6.version=aem63
 
 #AEM Commerce settings


### PR DESCRIPTION
1. There were errors in acs-aem-commons-content packages' urls.
2. ACS versions updated to latest.