### PR TITLE
AEM OSGI Hotfixes' versions updated

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -480,10 +480,10 @@ demo.download.hotfix.11099.version=aem62
 demo.download.osgi.thread61.core=http://www-us.apache.org/dist/sling/org.apache.sling.commons.threads-3.2.6.jar
 demo.download.osgi.thread61.version=aem61
 demo.download.osgi.thread61.startlevel=15
-demo.download.osgi.scheduler61.core=http://www-us.apache.org/dist/sling/org.apache.sling.commons.scheduler-2.5.0.jar
+demo.download.osgi.scheduler61.core=http://www-us.apache.org/dist/sling/org.apache.sling.commons.scheduler-2.5.2.jar
 demo.download.osgi.scheduler61.version=aem61
 demo.download.osgi.scheduler61.startlevel=19
-demo.download.osgi.scheduler62.core=http://www-us.apache.org/dist/sling/org.apache.sling.commons.scheduler-2.5.0.jar
+demo.download.osgi.scheduler62.core=http://www-us.apache.org/dist/sling/org.apache.sling.commons.scheduler-2.5.2.jar
 demo.download.osgi.scheduler62.version=aem62
 demo.download.osgi.scheduler62.startlevel=19
 


### PR DESCRIPTION
AEM OSGI Hotfixes versions updated, previously specified url is illegal a the moment